### PR TITLE
Add support em1 and p1p1 device names

### DIFF
--- a/cf/include/util.h
+++ b/cf/include/util.h
@@ -160,6 +160,22 @@ cf_digest_compare( cf_digest *d1, cf_digest *d2 )
 }
 #endif
 
+/* cf_strcount
+ * Count the number of non-overlapping instances of sep in s */
+static inline int
+cf_strcount(const char* s, const char* sep)
+{
+    int l = strlen(sep);
+    int count = 0;
+
+    while ((s = strstr(s, sep))) {
+        count++;
+        s += l;
+    }
+
+    return count;
+}
+
 // Sorry, too lazy to create a whole new file for just one function
 #define CF_NODE_UNSET (0xFFFFFFFFFFFFFFFF)
 typedef uint64_t cf_node;


### PR DESCRIPTION
I had an issue starting a new cluster where multiple nodes got the same node-id because the IP address was not detected properly.

The latest version of Ubuntu (also RedHat and Fedora) use biosdevname consistent device naming[1] for network interfaces. This results in interfaces having the names `em<port number>` for onboard devices and `p<slot number>p<port number>` for PCI devices.

I couldn't find any tests so I'm not 100% sure this will always work properly. Are there any tests I can run or modify for this?

The way these changes are made now also allows for `network-interface-name` in the config to be set to `eth%d` by the user. This change was unintentional but might be useful for some users?

This documentation will also need to be updated: http://www.aerospike.com/docs/reference/configuration/#network-interface-name

[1] For more information see: https://lists.ubuntu.com/archives/ubuntu-devel/2013-June/037203.html