### PR TITLE
logrotate shouldn't fail when the log is not there

### DIFF
--- a/as/etc/logrotate_asd
+++ b/as/etc/logrotate_asd
@@ -1,10 +1,11 @@
 /var/log/aerospike/aerospike.log {
+    missingok
     daily
     rotate 90
     dateext
     compress
     olddir /var/log/aerospike/
     postrotate 
-	kill -HUP `cat /var/run/aerospike/asd.pid`
+        kill -HUP `cat /var/run/aerospike/asd.pid`
     endscript
 }


### PR DESCRIPTION
When you install the server but never start it logrotate will start failing since it expects the logfile to be there.