### PR TITLE
Fix bug #122 aerospike-server fails to build on ppc64le

### DIFF
--- a/as/src/Makefile
+++ b/as/src/Makefile
@@ -113,6 +113,7 @@ else
       $(wildcard /usr/lib64/liblua$(LUA_SUFFIX).a), \
       $(wildcard /usr/lib/x86_64-linux-gnu/liblua$(LUA_SUFFIX).a), \
       $(wildcard /usr/lib/liblua.a), \
+      $(wildcard /usr/lib/powerpc64le-linux-gnu/liblua.a), \
       $(error Cannot find "liblua.a"))
   else
     LIBRARIES += -llua$(LUA_SUFFIX)

--- a/make_in/Makefile.in
+++ b/make_in/Makefile.in
@@ -33,6 +33,7 @@ ifeq ($(LD_CRYPTO),static)
     $(wildcard /usr/lib64/libcrypto.a), \
     $(wildcard /usr/lib/x86_64-linux-gnu/libcrypto.a), \
     $(wildcard /usr/lib/libcrypto.a), \
+    $(wildcard /usr/lib/powerpc64le-linux-gnu/libcrypto.a), \
     $(error Cannot find "libcrypto.a"))
 else
   LIBRARIES = -lcrypto
@@ -133,7 +134,9 @@ endif
 COMMON_CFLAGS = -gdwarf-$(DWARF_VERSION) -g3 $(OPTFLAGS) -fno-common -fno-strict-aliasing -Wall $(AS_CFLAGS)
 
 # Code generated for the "nocona" architecture has been determined to run well on a wide variety of current machines.
-COMMON_CFLAGS += -march=nocona
+ifneq ($(ARCH),$(filter $(ARCH),ppc64 ppc64le))
+  COMMON_CFLAGS += -march=nocona
+endif
 
 # Generate dependency files.
 COMMON_CFLAGS += -MMD

--- a/make_in/Makefile.vars
+++ b/make_in/Makefile.vars
@@ -35,7 +35,11 @@ endif
 USE_JEM = 1
 
 # Use LuaJIT instead of Lua?  [By default, yes.]
-USE_LUAJIT = 1
+ifeq ($(ARCH),$(filter $(ARCH),ppc64 ppc64le))
+  USE_LUAJIT = 0
+else
+  USE_LUAJIT = 1
+endif
 
 # Use the Key-Value Store API?  [By default, no.]
 USE_KV = 0

--- a/make_in/Makefile.vars
+++ b/make_in/Makefile.vars
@@ -145,4 +145,5 @@ ASMALLOC = $(ASMALLOC_PATH)
 JEMALLOC = $(JEMALLOC_PATH)
 LUAJIT   = $(LUAJIT_PATH)
 S2       = $(S2_PATH)
+ARCH     = $(shell arch)
 


### PR DESCRIPTION
Excluding LuaJIT, which currently doesn't support ppc64le, and other minor Makefile fixes to support the ppc64 architecture.