### PR TITLE
Update cfg.c

### DIFF
--- a/as/src/base/cfg.c
+++ b/as/src/base/cfg.c
@@ -1393,6 +1393,10 @@ cfg_strdup_one_of(const cfg_line* p_line, const char* toks[], int num_toks)
 
 	char valid_toks[valid_toks_size];
 
+	for (int i = 0; i < valid_toks_size; i++) {
+		valid_toks[i] = NULL;
+	}
+	
 	for (int i = 0; i < num_toks; i++) {
 		strcat(valid_toks, toks[i]);
 		strcat(valid_toks, ", ");


### PR DESCRIPTION
```
Checking ../aerospike-server-master/as/src/base/cfg.c...
[../aerospike-server-master/as/src/base/cfg.c:1398]: (error) Uninitialized variable: valid_toks
16/101 files checked 14% done
```

**It's always good to initialize pointers, at least to NULL, because if you try to dereference the pointer before it gets assigned any actual (non-garbage) value, then you run the risk of dereferencing a garbage address that might cause your program to crash, or worse, might corrupt memory.**

Found by https://github.com/bryongloden/cppcheck