### PR TITLE
Update particle_map.c

### DIFF
--- a/as/src/base/particle_map.c
+++ b/as/src/base/particle_map.c
@@ -1734,8 +1734,8 @@ packed_map_increment(as_bin *b, rollback_alloc *alloc_buf, const cdt_payload *ke
 		return -AS_PROTO_RESULT_FAIL_PARAMETER;
 	}
 
-	int64_t incr_int;
-	double incr_double;
+	int64_t incr_int = 0;
+	double incr_double = 0;
 	as_val_t delta_value_type;
 
 	if (delta_value) {


### PR DESCRIPTION
```
Checking ../aerospike-server-master/as/src/base/particle_map.c...
[../aerospike-server-master/as/src/base/particle_map.c:1774]: (error) Uninitialized variable: incr_int
[../aerospike-server-master/as/src/base/particle_map.c:1775]: (error) Uninitialized variable: incr_double
Checking ../aerospike-server-master/as/src/base/particle_map.c: MAP_DEBUG_VERIFY...
34/101 files checked 42% done
```

Found by https://github.com/bryongloden/cppcheck
