### PR TITLE
Port to SmartOS

### DIFF
--- a/ai/src/ai.c
+++ b/ai/src/ai.c
@@ -25,6 +25,8 @@
  *    the Aerospike Index module.
  */
 
+#include <strings.h>
+
 #include <citrusleaf/alloc.h>
 #include <citrusleaf/cf_shash.h>
 #include <citrusleaf/cf_ll.h>

--- a/ai/src/ai_btree.c
+++ b/ai/src/ai_btree.c
@@ -29,6 +29,7 @@
 #include <pthread.h>
 #include <stdio.h>
 #include <string.h>
+#include <strings.h>
 
 #include "ai.h"
 #include "ai_globals.h"

--- a/as/include/base/cfg.h
+++ b/as/include/base/cfg.h
@@ -74,6 +74,10 @@ struct as_namespace_s;
 #define MSG_NOSIGNAL 0
 #endif
 
+#ifndef MSG_MORE
+#define MSG_MORE 0
+#endif
+
 typedef struct as_config_s {
 
 	// The order here matches that in the configuration parser's enum,

--- a/as/include/base/cfg.h
+++ b/as/include/base/cfg.h
@@ -70,6 +70,10 @@ struct as_namespace_s;
 #define PBOOL(line) bool PGLUE(pad_, line)[3]; bool
 #define PAD_BOOL PBOOL(__LINE__)
 
+#ifndef MSG_NOSIGNAL
+#define MSG_NOSIGNAL 0
+#endif
+
 typedef struct as_config_s {
 
 	// The order here matches that in the configuration parser's enum,

--- a/as/include/base/cfg.h
+++ b/as/include/base/cfg.h
@@ -78,6 +78,14 @@ struct as_namespace_s;
 #define MSG_MORE 0
 #endif
 
+#ifndef MAX
+#define MAX(a,b) ((a)<(b) ? (b) : (a))
+#endif
+
+#ifndef MIN
+#define MIN(a,b) ((a)<(b) ? (a) : (b))
+#endif
+
 typedef struct as_config_s {
 
 	// The order here matches that in the configuration parser's enum,

--- a/as/src/Makefile
+++ b/as/src/Makefile
@@ -175,7 +175,7 @@ check-syntax:
 $(SERVER): $(OBJECTS) $(AS_LIB_DEPS)
 ifneq ($(PREPRO),1)
   ifneq ($(MEXP_PHASE),1)
-	$(LINK.c) -o $(SERVER) $(OBJECTS) $(LIBRARIES)
+	$(LINK.cc) -o $(SERVER) $(OBJECTS) $(LIBRARIES)
   endif
 endif
 

--- a/as/src/Makefile
+++ b/as/src/Makefile
@@ -104,6 +104,10 @@ ifeq ($(DOPROFILE),1)
   LIBRARIES += -pg -fprofile-arcs -lgcov
 endif
 
+ifeq ($(shell uname),SunOS)
+  AS_LIBRARIES += -lsocket -lnsl
+endif
+
 # Add either the LuaJIT or Lua library
 ifeq ($(USE_LUAJIT),1)
   ifeq ($(LD_LUAJIT),static)

--- a/as/src/base/aggr.c
+++ b/as/src/base/aggr.c
@@ -26,6 +26,7 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <string.h>
+#include <strings.h>
 
 
 #include "aerospike/as_val.h"

--- a/as/src/base/as.c
+++ b/as/src/base/as.c
@@ -30,7 +30,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <syscall.h>
 #include <unistd.h>
 #include <sys/stat.h>
 

--- a/as/src/base/proto.c
+++ b/as/src/base/proto.c
@@ -35,6 +35,7 @@
 #include <asm/byteorder.h>
 #include <netinet/in.h>
 #include <sys/socket.h>
+#include <endian.h>
 
 #include "aerospike/as_val.h"
 #include "citrusleaf/alloc.h"
@@ -60,7 +61,7 @@ as_proto_swap(as_proto *p)
 	uint8_t	 version = p->version;
 	uint8_t  type = p->type;
 	p->version = p->type = 0;
-	p->sz = __be64_to_cpup((__u64 *)p);
+	p->sz = be64toh(*(uint64_t*)p);
 	p->version = version;
 	p->type = type;
 }
@@ -852,7 +853,7 @@ uint8_t * as_msg_write_fields(uint8_t *buf, const char *ns, int ns_len,
 	if (trid) {
 		mf->type = AS_MSG_FIELD_TYPE_TRID;
 		//Convert the transaction-id to network byte order (big-endian)
-		uint64_t trid_nbo = __cpu_to_be64(trid); //swaps in place
+		uint64_t trid_nbo = htobe64(trid); //swaps in place
 		mf->field_sz = sizeof(trid_nbo) + 1;
 		//printf("write_fields: trid: write_fields: %d\n", mf->field_sz);
 		memcpy(mf->data, &trid_nbo, sizeof(trid_nbo));

--- a/as/src/base/secondary_index.c
+++ b/as/src/base/secondary_index.c
@@ -82,6 +82,7 @@
 #include <limits.h>
 #include <string.h>
 #include <pthread.h>
+#include <endian.h>
 
 #include "citrusleaf/cf_atomic.h"
 #include "citrusleaf/cf_clock.h"
@@ -2789,7 +2790,7 @@ as_sindex_range_from_msg(as_namespace *ns, as_msg *msgp, as_sindex_range *srange
 					"Can only handle 8 byte numerics right now %u", startl);
 				goto Cleanup;
 			}
-			start->u.i64  = __cpu_to_be64(*((uint64_t *)data));
+			start->u.i64  = htobe64(*((uint64_t *)data));
 			data         += sizeof(uint64_t);
 
 			// get end point
@@ -2800,7 +2801,7 @@ as_sindex_range_from_msg(as_namespace *ns, as_msg *msgp, as_sindex_range *srange
 						"can only handle 8 byte numerics right now %u", endl);
 				goto Cleanup;
 			}
-			end->u.i64  = __cpu_to_be64(*((uint64_t *)data));
+			end->u.i64  = htobe64(*((uint64_t *)data));
 			data       += sizeof(uint64_t);
 			if (start->u.i64 > end->u.i64) {
 				cf_warning(AS_SINDEX,

--- a/as/src/base/secondary_index.c
+++ b/as/src/base/secondary_index.c
@@ -505,11 +505,13 @@ as_sindex__dup_meta(as_sindex_metadata *imd, as_sindex_metadata **qimd,
 	if (pthread_rwlockattr_init(&rwattr))
 		cf_crash(AS_AS,  "pthread_rwlockattr_init: %s",
 					cf_strerror(errno));
+#ifdef PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP
 	if (pthread_rwlockattr_setkind_np(&rwattr,
 				PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP)) {
 		cf_crash( AS_TSVC, "pthread_rwlockattr_setkind_np: %s",
 				cf_strerror(errno));
 	}
+#endif
 	if (pthread_rwlock_init(&qimdp->slock, &rwattr)) {
 		cf_crash(AS_SINDEX,
 				"Could not create secondary index dml mutex ");
@@ -1682,10 +1684,12 @@ as_sindex__create_pmeta(as_sindex *si, int simatch, int nptr)
 	if (pthread_rwlockattr_init(&rwattr))
 		cf_crash(AS_AS,
 				"pthread_rwlockattr_init: %s", cf_strerror(errno));
+#ifdef PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP
 	if (pthread_rwlockattr_setkind_np(&rwattr,
 				PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP))
 		cf_crash(AS_TSVC,
 				"pthread_rwlockattr_setkind_np: %s",cf_strerror(errno));
+#endif
 
 	for (int i = 0; i < nptr; i++) {
 		as_sindex_pmetadata *pimd = &si->imd->pimd[i];

--- a/as/src/base/secondary_index.c
+++ b/as/src/base/secondary_index.c
@@ -81,6 +81,7 @@
 #include <errno.h>
 #include <limits.h>
 #include <string.h>
+#include <pthread.h>
 
 #include "citrusleaf/cf_atomic.h"
 #include "citrusleaf/cf_clock.h"

--- a/as/src/base/signal.c
+++ b/as/src/base/signal.c
@@ -55,6 +55,8 @@ extern bool g_startup_complete;
 // Local helpers.
 //
 
+typedef void (*sighandler_t)(int);
+
 static inline void
 register_signal_handler(int sig_num, sighandler_t handler)
 {

--- a/as/src/base/thr_demarshal.c
+++ b/as/src/base/thr_demarshal.c
@@ -33,7 +33,6 @@
 #include <netinet/tcp.h>
 #include <sys/epoll.h>
 #include <sys/ioctl.h>
-#include <sys/param.h>	// for MIN()
 #include <sys/resource.h>
 #include <sys/socket.h>
 #include <sys/stat.h>

--- a/as/src/base/thr_demarshal.c
+++ b/as/src/base/thr_demarshal.c
@@ -373,7 +373,7 @@ thr_demarshal_config_xdr(int fd)
 
 	int arg = XDR_READ_BUFFER_SIZE;
 
-	if (setsockopt(fd, SOL_TCP, TCP_WINDOW_CLAMP, &arg, sizeof arg) < 0) {
+	if (setsockopt(fd, IPPROTO_TCP, TCP_WINDOW_CLAMP, &arg, sizeof arg) < 0) {
 		cf_crash(AS_DEMARSHAL, "Failed to set TCP window on FD %d, error %d (%s)",
 				fd, errno, strerror(errno));
 		return -1;
@@ -381,7 +381,7 @@ thr_demarshal_config_xdr(int fd)
 
 	arg = 0;
 
-	if (setsockopt(fd, SOL_TCP, TCP_NODELAY, &arg, sizeof arg) < 0) {
+	if (setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &arg, sizeof arg) < 0) {
 		cf_crash(AS_DEMARSHAL, "Failed to re-enable Nagle algorithm on FD %d, error %d (%s)",
 				fd, errno, strerror(errno));
 		return -1;

--- a/as/src/base/thr_demarshal.c
+++ b/as/src/base/thr_demarshal.c
@@ -373,11 +373,13 @@ thr_demarshal_config_xdr(int fd)
 
 	int arg = XDR_READ_BUFFER_SIZE;
 
+#ifdef TCP_WINDOW_CLAMP
 	if (setsockopt(fd, IPPROTO_TCP, TCP_WINDOW_CLAMP, &arg, sizeof arg) < 0) {
 		cf_crash(AS_DEMARSHAL, "Failed to set TCP window on FD %d, error %d (%s)",
 				fd, errno, strerror(errno));
 		return -1;
 	}
+#endif
 
 	arg = 0;
 

--- a/as/src/base/thr_demarshal.c
+++ b/as/src/base/thr_demarshal.c
@@ -37,6 +37,9 @@
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#ifdef __sun
+#include <sys/filio.h>
+#endif
 
 #include "citrusleaf/alloc.h"
 #include "citrusleaf/cf_atomic.h"

--- a/as/src/base/thr_info.c
+++ b/as/src/base/thr_info.c
@@ -32,7 +32,10 @@
 #include <ctype.h>
 #include <limits.h>
 #include <malloc.h>
+#ifdef __GNU_LIBRARY__
 #include <mcheck.h>
+#define AS_USE_GLIBC_MCHECK
+#endif
 #include <sys/epoll.h>
 #include <sys/ioctl.h>
 #include <sys/resource.h>
@@ -160,7 +163,9 @@ msg_template info_mt[] = {
 bool g_mstats_enabled = false;
 
 // Is GLibC-level memory tracing enabled?
+#ifdef AS_USE_GLIBC_MCHECK
 static bool g_mtrace_enabled = false;
+#endif
 
 // Default location for the memory tracing output:
 #define DEFAULT_MTRACE_FILENAME  "/tmp/mtrace.out"
@@ -1231,6 +1236,7 @@ info_command_mstats(char *name, char *params, cf_dyn_buf *db)
 
 	cf_debug(AS_INFO, "mstats command received: params %s", params);
 
+#ifdef AS_USE_GLIBC_MCHECK
 	/*
 	 *  Command Format:  "mstats:{enable=<opt>}" [the "enable" argument is optional]
 	 *
@@ -1262,6 +1268,7 @@ info_command_mstats(char *name, char *params, cf_dyn_buf *db)
 	}
 
 	cf_dyn_buf_append_string(db, "ok");
+#endif
 
 	return 0;
 }
@@ -1275,6 +1282,7 @@ info_command_mtrace(char *name, char *params, cf_dyn_buf *db)
 
 	cf_debug(AS_INFO, "mtrace command received: params %s", params);
 
+#ifdef AS_USE_GLIBC_MCHECK
 	/*
 	 *  Command Format:  "mtrace:{enable=<opt>}" [the "enable" argument is optional]
 	 *
@@ -1311,6 +1319,7 @@ info_command_mtrace(char *name, char *params, cf_dyn_buf *db)
 	}
 
 	cf_dyn_buf_append_string(db, "ok");
+#endif
 
 	return 0;
 }

--- a/as/src/base/thr_info_port.c
+++ b/as/src/base/thr_info_port.c
@@ -32,6 +32,9 @@
 #include <sys/epoll.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
+#ifdef __sun
+#include <sys/filio.h>
+#endif
 
 #include "citrusleaf/alloc.h"
 #include "citrusleaf/cf_atomic.h"

--- a/as/src/base/thr_nsup.c
+++ b/as/src/base/thr_nsup.c
@@ -34,7 +34,6 @@
 #include <string.h>
 #include <time.h>
 #include <unistd.h>
-#include <sys/param.h> // for MIN and MAX
 
 #include "citrusleaf/alloc.h"
 #include "citrusleaf/cf_atomic.h"

--- a/as/src/base/thr_query.c
+++ b/as/src/base/thr_query.c
@@ -297,7 +297,10 @@ typedef struct qtr_skey_s {
 // **************************************************************************************************
 static int              g_current_queries_count = 0;
 static pthread_rwlock_t g_query_lock
-						= PTHREAD_RWLOCK_WRITER_NONRECURSIVE_INITIALIZER_NP;
+#ifdef PTHREAD_RWLOCK_WRITER_NONRECURSIVE_INITIALIZER_NP
+						= PTHREAD_RWLOCK_WRITER_NONRECURSIVE_INITIALIZER_NP
+#endif
+;
 static rchash         * g_query_job_hash = NULL;
 // Buf Builder Pool
 static cf_queue       * g_query_response_bb_pool  = 0;

--- a/as/src/base/thr_sindex.c
+++ b/as/src/base/thr_sindex.c
@@ -533,8 +533,10 @@ as_sindex_thr_init()
 	}
 	if (0 != pthread_rwlockattr_init(&rwattr))
 		cf_crash(AS_SINDEX, "pthread_rwlockattr_init: %s", cf_strerror(errno));
+#ifdef PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP
 	if (0 != pthread_rwlockattr_setkind_np(&rwattr, PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP))
 		cf_crash( AS_SINDEX, "pthread_rwlockattr_setkind_np: %s", cf_strerror(errno));
+#endif
 
 	// Aerospike Index Metadata lock
 	if (0 != pthread_rwlock_init(&g_ai_rwlock, &rwattr)) {

--- a/as/src/base/ticker.c
+++ b/as/src/base/ticker.c
@@ -27,7 +27,10 @@
 #include "base/ticker.h"
 
 #include <malloc.h>
+#ifdef __GNU_LIBRARY__
+#define AS_USE_GLIBC_MCHECK
 #include <mcheck.h>
+#endif
 #include <pthread.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -727,6 +730,7 @@ dump_namespace_histograms(as_namespace* ns)
 void
 log_mem_stats(size_t total_ns_memory_inuse)
 {
+#ifdef AS_USE_GLIBC_MCHECK
 #ifdef MEM_COUNT
 	if (g_config.memory_accounting) {
 		mem_count_stats();
@@ -788,4 +792,5 @@ log_mem_stats(size_t total_ns_memory_inuse)
 	if (g_mstats_enabled) {
 		info_log_with_datestamp(malloc_stats);
 	}
+#endif
 }

--- a/as/src/base/ticker.c
+++ b/as/src/base/ticker.c
@@ -34,7 +34,6 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <time.h>
-#include <sys/param.h>
 
 #include "citrusleaf/alloc.h"
 #include "citrusleaf/cf_atomic.h"

--- a/as/src/fabric/fabric.c
+++ b/as/src/fabric/fabric.c
@@ -890,7 +890,7 @@ fabric_process_writable(fabric_buffer *fb)
 
 	if (fb->nodelay_isset == false) {
 		int flag = 1;
-		setsockopt(fb->fd, SOL_TCP, TCP_NODELAY, &flag, sizeof(flag));
+		setsockopt(fb->fd, IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(flag));
 		fb->nodelay_isset = true;
 	}
 

--- a/as/src/fabric/fabric.c
+++ b/as/src/fabric/fabric.c
@@ -1326,8 +1326,6 @@ fabric_worker_fn(void *argv)
 	note_so.sun_family = AF_UNIX;
 	strcpy(note_so.sun_path, fa->note_sockname);
 	int len = sizeof(note_so.sun_family) + strlen(note_so.sun_path) + 1;
-	// Use an abstract Unix domain socket [Note:  Linux-specific!] by setting the first path character to NUL.
-	note_so.sun_path[0] = '\0';
 	if (connect(note_fd, (struct sockaddr *) &note_so, len) == -1) {
 		cf_crash(AS_FABRIC, "could not connect to notification socket");
 		return(0);
@@ -1869,11 +1867,9 @@ as_fabric_start()
 	struct sockaddr_un ns_so;
 	memset(&ns_so, 0, sizeof(ns_so));
 	ns_so.sun_family = AF_UNIX;
-	snprintf(&fa->note_sockname[0], sizeof(ns_so.sun_path), "@/tmp/wn-%d", getpid());
+	snprintf(&fa->note_sockname[0], sizeof(ns_so.sun_path), "/tmp/wn-%d", getpid());
 	strcpy(ns_so.sun_path, fa->note_sockname);
 	int ns_so_len = sizeof(ns_so.sun_family) + strlen(ns_so.sun_path) + 1;
-	// Use an abstract Unix domain socket [Note:  Linux-specific!] by setting the first path character to NUL.
-	ns_so.sun_path[0] = '\0';
 	if (0 > bind(fa->note_server_fd, (struct sockaddr *)&ns_so, ns_so_len)) {
 		cf_crash(AS_FABRIC,
 				 "could not bind note server name %s: %d %s", ns_so.sun_path, errno, cf_strerror(errno));

--- a/as/src/storage/drv_ssd.c
+++ b/as/src/storage/drv_ssd.c
@@ -47,6 +47,7 @@
 #include <linux/fs.h> // for BLKGETSIZE64
 #include <sys/ioctl.h>
 #include <sys/param.h> // for MAX()
+#include <sys/stat.h>
 
 #include "citrusleaf/alloc.h"
 #include "citrusleaf/cf_atomic.h"

--- a/as/src/storage/drv_ssd.c
+++ b/as/src/storage/drv_ssd.c
@@ -3195,7 +3195,7 @@ ssd_load_devices_fn(void *udata)
 	cf_info(AS_DRV_SSD, "device %s: reading device to load index", ssd->name);
 
 #ifdef USE_JEM
-	int tid = syscall(SYS_gettid);
+	long tid = pthread_self();
 	cf_info(AS_DRV_SSD, "In TID %d: Using arena #%d for loading data for namespace \"%s\"",
 			tid, ssds->ns->jem_arena, ssds->ns->name);
 

--- a/build/VersionCheck.py
+++ b/build/VersionCheck.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 #
 # VersionCheck.py:

--- a/build/os_version
+++ b/build/os_version
@@ -42,7 +42,8 @@ main() {
 	if [ "$kernel" != 'linux' ]
 	then
 		error "$kernel is not supported."
-		exit 1
+		echo "$kernel"
+		exit
 	fi
 
 	if [ -f /etc/os-release ]

--- a/cf/include/enhanced_alloc.h
+++ b/cf/include/enhanced_alloc.h
@@ -27,6 +27,18 @@
 #include <stddef.h>
 #include <citrusleaf/cf_atomic.h>
 
+#ifndef MEM_COUNT
+
+#define cf_calloc(nmemb, size) calloc(nmemb, size)
+#define cf_malloc(size) malloc(size)
+#define cf_free(ptr) free(ptr)
+#define cf_realloc(ptr, size) realloc(ptr, size)
+#define cf_strdup(s) strdup(s)
+#define cf_strndup(s, n) strndup(s, n)
+#define cf_valloc(size) valloc(size)
+
+#else
+
 #ifdef PREPRO
 
 // For generating code via the C pre-processor:
@@ -91,6 +103,8 @@ void *cf_valloc_at(size_t sz, char *file, int line);
 void cf_free_at(void *p, char *file, int line);
 
 #endif // !defined(PREPRO) && !defined(USE_ASM)
+
+#endif // def MEM_COUNT
 
 /*
  * The "cf_rc_*()" Functions:  Reference Counting Allocation:

--- a/cf/include/util.h
+++ b/cf/include/util.h
@@ -29,6 +29,14 @@
 #include <sys/types.h>
 #include <citrusleaf/cf_digest.h>
 
+#include <sys/param.h>
+#ifndef MIN
+#define MIN(a, b) ((a)<(b) ? (a) : (b))
+#endif
+#ifndef MAX
+#define MAX(a, b) ((a)<(b) ? (b) : (a))
+#endif
+
 // TODO - as_ .c files depend on this:
 #include <asm/byteorder.h>
 

--- a/cf/src/alloc.c
+++ b/cf/src/alloc.c
@@ -43,7 +43,7 @@
 #include <citrusleaf/cf_types.h> // for byte
 
 #include "fault.h"
-
+#include "util.h"
 
 // #define USE_CIRCUS 1
 

--- a/cf/src/dynbuf.c
+++ b/cf/src/dynbuf.c
@@ -367,7 +367,7 @@ cf_buf_builder_append_uint64 (cf_buf_builder **bb_r, uint64_t i)
 	BB_RESERVE(8);
 	cf_buf_builder *bb = *bb_r;
 	uint64_t *i_p = (uint64_t *) &bb->buf[bb->used_sz];
-	*i_p = __swab64(i);
+	*i_p = __builtin_bswap64(i);
 	bb->used_sz += 8;
 	return( 0 );
 }

--- a/cf/src/fault.c
+++ b/cf/src/fault.c
@@ -35,6 +35,8 @@
 #include <time.h>
 #include <unistd.h>
 
+#include <sys/stat.h>
+
 #include <aerospike/as_log.h>
 #include <citrusleaf/alloc.h>
 #include <citrusleaf/cf_b64.h>

--- a/cf/src/id.c
+++ b/cf/src/id.c
@@ -33,6 +33,9 @@
 #include <arpa/inet.h>
 #include <net/if.h>
 #include <netinet/in.h>
+#ifdef __sun
+#define BSD_COMP
+#endif
 #include <sys/ioctl.h>
 #include <sys/socket.h>
 

--- a/cf/src/id.c
+++ b/cf/src/id.c
@@ -170,7 +170,7 @@ check_mac_and_get_ipaddr(int fdesc, const char *ifname, struct ifreq *req, char 
 		return false;
 	}
 
-	uint8_t *mac = (uint8_t *)req->ifr_ifru.ifru_hwaddr.sa_data;
+	uint8_t *mac = (uint8_t *)req->ifr_ifru.ifru_addr.sa_data;
 
 	static const uint8_t zero[6] = {0, 0, 0, 0, 0, 0};
 	static const uint8_t ff[6] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
@@ -331,7 +331,7 @@ cf_nodeid_get(unsigned short port, cf_node *id, char **node_ipp, hb_mode_enum hb
 	}
 
 	*id = 0;
-	memcpy(id, req.ifr_hwaddr.sa_data, 6);
+	memcpy(id, req.ifr_addr.sa_data, 6);
 	memcpy(((byte *)id) + 6, &port, 2);
 
 	cf_debug(CF_MISC, "port %d id %"PRIx64, port, *id);

--- a/cf/src/jem.c
+++ b/cf/src/jem.c
@@ -33,6 +33,7 @@
 #include <unistd.h>
 #include <jemalloc/jemalloc.h>
 #include <sys/syscall.h>
+#include <pthread.h>
 
 #include "fault.h"
 

--- a/cf/src/jem.c
+++ b/cf/src/jem.c
@@ -152,7 +152,7 @@ int jem_get_arena(void)
 
 	if (jem_enabled) {
 		size_t len = sizeof(unsigned);
-		int tid = syscall(SYS_gettid);
+		long tid = pthread_self();
 
 		if ((retval = mallctlbymib(thread_arena_mib, thread_arena_miblen, &orig_arena, &len, NULL, 0))) {
 			cf_warning(CF_JEM, "In TID %d:  Failed to get arena!", tid);
@@ -175,7 +175,7 @@ int jem_set_arena(int arena)
 	if (jem_enabled && (0 <= arena)) {
 		unsigned orig_arena = 0;
 		size_t len = sizeof(unsigned);
-		int tid = syscall(SYS_gettid);
+		long tid = pthread_self();
 
 		if ((retval = mallctlbymib(thread_arena_mib, thread_arena_miblen, &orig_arena, &len, &arena, len))) {
 			cf_warning(CF_JEM, "Failed to set arena to #%d for TID %d! (rv %d ; errno %d)", arena, tid, retval, errno);
@@ -198,7 +198,7 @@ int jem_enable_tcache(bool enabled)
 	if (jem_enabled) {
 		bool orig_enabled;
 		size_t len = sizeof(bool);
-		int tid = syscall(SYS_gettid);
+		long tid = pthread_self();
 
 		if ((retval = mallctlbymib(thread_tcache_enabled_mib, thread_tcache_enabled_miblen, &orig_enabled, &len, &enabled, len))) {
 			cf_warning(CF_JEM, "Failed to set tcached enabled to %d for TID %d (errno %d)!", enabled, tid, errno);
@@ -221,7 +221,7 @@ void *jem_allocate_in_arena(int arena, size_t size, bool use_allocm)
 
 	if (jem_enabled) {
 		int retval = -1;
-		int tid = syscall(SYS_gettid);
+		long tid = pthread_self();
 
 		if (jem_enabled) {
 			if (use_allocm) {

--- a/cf/src/msg.c
+++ b/cf/src/msg.c
@@ -1134,7 +1134,7 @@ msg_dump(const msg *m, const char *info)
 					int n_ints = mf->field_len >> 2;
 					for (int j = 0; j < n_ints; j++) {
 						cf_info(CF_MSG, "      idx %d value %u",
-								j, ntohl(mf->u.ui32_a[j]));
+								j, cf_swap_from_be32(mf->u.ui32_a[j]));
 					}
 				}
 				break;
@@ -1146,7 +1146,7 @@ msg_dump(const msg *m, const char *info)
 					int n_ints = mf->field_len >> 3;
 					for (int j = 0; j < n_ints; j++) {
 						cf_info(CF_MSG, "      idx %d value %lu",
-								j, __bswap_64(mf->u.ui64_a[j]));
+								j, cf_swap_from_be64(mf->u.ui64_a[j]));
 					}
 				}
 				break;

--- a/cf/src/socket.c
+++ b/cf/src/socket.c
@@ -99,7 +99,7 @@ void
 cf_socket_set_nodelay(int s)
 {
 	int flag = 1;
-	setsockopt(s, SOL_TCP, TCP_NODELAY, &flag, sizeof(flag));
+	setsockopt(s, IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(flag));
 }
 
 
@@ -393,7 +393,7 @@ Success:	;
 	// regarding this: calling here doesn't seem terribly effective.
 	// on the fabric threads, it seems important to set no-delay much later
 	int flag = 1;
-	setsockopt(s->sock, SOL_TCP, TCP_NODELAY, &flag, sizeof(flag));
+	setsockopt(s->sock, IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(flag));
 	long farg = fcntl(s->sock, F_GETFL, 0);
 	fcntl(s->sock, F_SETFL, farg & (~O_NONBLOCK)); /* blocking again */
 

--- a/cf/src/socket.c
+++ b/cf/src/socket.c
@@ -42,6 +42,9 @@
 
 #include "fault.h"
 
+#ifndef MSG_NOSIGNAL
+#define MSG_NOSIGNAL 0
+#endif
 
 void
 cf_sockaddr_convertto(const struct sockaddr_in *src, cf_sockaddr *dst)

--- a/cf/src/socket.c
+++ b/cf/src/socket.c
@@ -32,7 +32,6 @@
 #include <time.h>
 #include <unistd.h>
 #include <arpa/inet.h>
-#include <asm-generic/socket.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <sys/epoll.h>


### PR DESCRIPTION
This port to SmartOS (Solaris-derived OS) is incomplete, in that `MEM_COUNT` is not supported.  Using standard Lua, this port can pass `make test` of the C client.  LuaJIT segfaults when running tests, I have not yet figured out why.

This PR is incomplete, changes to submodules will come in other PRs.