### PR TITLE
fix uninitialized variables

### DIFF
--- a/as/src/base/particle_map.c
+++ b/as/src/base/particle_map.c
@@ -1749,8 +1749,8 @@ packed_map_increment(as_bin *b, rollback_alloc *alloc_buf, const cdt_payload *ke
 		return -AS_PROTO_RESULT_FAIL_PARAMETER;
 	}
 
-	int64_t incr_int;
-	double incr_double;
+	int64_t incr_int = 1;
+	double incr_double = 1;
 	as_val_t delta_value_type;
 
 	if (delta_value) {


### PR DESCRIPTION
On line number 1789 of [particle_map.c](https://github.com/aerospike/aerospike-server/blob/master/as/src/base/particle_map.c#L1789), `incr_int` may be accessed without an initialized value. Similarly, on line number 1790 of [particle_map.c](https://github.com/aerospike/aerospike-server/blob/master/as/src/base/particle_map.c#L1790), `incr_double` may be accessed without an initialized value. It's always good to initialize variables, because if we try to access a value before it gets assigned any actual (non-garbage) value, then it results in undefined behavior.

Found by https://github.com/bryongloden/cppcheck
