### PR TITLE
use cf_atomic32_setmax for updating cold_start_threshold_void_time

### DIFF
--- a/as/src/base/thr_nsup.c
+++ b/as/src/base/thr_nsup.c
@@ -308,9 +308,7 @@ as_cold_start_evict_if_needed(as_namespace* ns)
 	uint32_t now = as_record_void_time_get();
 
 	// Update threshold void-time if we're past it.
-	if (now > cf_atomic32_get(ns->cold_start_threshold_void_time)) {
-		cf_atomic32_set(&ns->cold_start_threshold_void_time, now);
-	}
+	cf_atomic32_setmax(&ns->cold_start_threshold_void_time, now);
 
 	// Are we out of control?
 	if (eval_stop_writes(ns)) {


### PR DESCRIPTION
An atomic fetch, followed by an atomic set, doesn't make the combined operations atomic. Use the cf_atomic32_setmax for this.

While now is measured in seconds, its quite possible that a thread could be delayed for over a second in before the cf_atomic32_set is called. During this delay another thread might update this to a more recent time. When the original thread gains control again, ns->cold_start_threshold_void_time is set to a lower value.