### PR TITLE
use cf atomics

### DIFF
--- a/as/include/base/datamodel.h
+++ b/as/include/base/datamodel.h
@@ -1136,7 +1136,7 @@ struct as_namespace_s {
 
 #define INVALID_SET_ID 0
 
-#define IS_SET_EVICTION_DISABLED(p_set)		(cf_atomic32_get(p_set->disable_eviction) == 1)
+#define IS_SET_EVICTION_DISABLED(p_set)		(cf_atomic32_get(&p_set->disable_eviction) == 1)
 #define DISABLE_SET_EVICTION(p_set, on_off)	(cf_atomic32_set(&p_set->disable_eviction, on_off ? 1 : 0))
 
 typedef enum {
@@ -1161,8 +1161,8 @@ struct as_set_s {
 
 static inline bool
 as_set_stop_writes(as_set *p_set) {
-	uint64_t n_objects = cf_atomic64_get(p_set->n_objects);
-	uint64_t stop_writes_count = cf_atomic64_get(p_set->stop_writes_count);
+	uint64_t n_objects = cf_atomic64_get(&p_set->n_objects);
+	uint64_t stop_writes_count = cf_atomic64_get(&p_set->stop_writes_count);
 
 	return stop_writes_count != 0 && n_objects >= stop_writes_count;
 }

--- a/as/src/base/index.c
+++ b/as/src/base/index.c
@@ -229,13 +229,13 @@ as_index_tree_release(as_index_tree *tree)
 		return 0;
 	}
 
-	int rc = cf_rc_release(tree);
+	unsigned rc = cf_rc_release(tree);
 
 	if (rc > 0) {
 		return 1;
 	}
 
-	cf_assert(rc == 0, AS_INDEX, "tree ref-count %d", rc);
+	cf_assert(rc == 0, AS_INDEX, "tree ref-count %u", rc);
 
 	// TODO - call as_index_tree_destroy() directly if tree is empty?
 

--- a/as/src/base/index.c
+++ b/as/src/base/index.c
@@ -249,7 +249,7 @@ as_index_tree_release(as_index_tree *tree)
 uint64_t
 as_index_tree_size(as_index_tree *tree)
 {
-	return tree ? cf_atomic64_get(tree->n_elements) : 0;
+	return tree ? cf_atomic64_get(&tree->n_elements) : 0;
 }
 
 

--- a/as/src/base/job_manager.c
+++ b/as/src/base/job_manager.c
@@ -379,7 +379,7 @@ as_job_info(as_job* _job, as_mon_jobstat* stat)
 	stat->progress_pct		= as_job_progress(_job);
 	stat->run_time			= active_ms;
 	stat->time_since_done	= since_finish_ms;
-	stat->recs_read			= cf_atomic64_get(_job->n_records_read);
+	stat->recs_read			= cf_atomic64_get(&_job->n_records_read);
 
 	strcpy(stat->ns, _job->ns->name);
 	strcpy(stat->set, as_job_safe_set_name(_job));

--- a/as/src/base/namespace.c
+++ b/as/src/base/namespace.c
@@ -720,15 +720,15 @@ append_set_props(as_set *p_set, cf_dyn_buf *db)
 	// Statistics:
 
 	cf_dyn_buf_append_string(db, "objects=");
-	cf_dyn_buf_append_uint64(db, cf_atomic64_get(p_set->n_objects));
+	cf_dyn_buf_append_uint64(db, cf_atomic64_get(&p_set->n_objects));
 	cf_dyn_buf_append_char(db, ':');
 
 	cf_dyn_buf_append_string(db, "tombstones=");
-	cf_dyn_buf_append_uint64(db, cf_atomic64_get(p_set->n_tombstones));
+	cf_dyn_buf_append_uint64(db, cf_atomic64_get(&p_set->n_tombstones));
 	cf_dyn_buf_append_char(db, ':');
 
 	cf_dyn_buf_append_string(db, "memory_data_bytes=");
-	cf_dyn_buf_append_uint64(db, cf_atomic64_get(p_set->n_bytes_memory));
+	cf_dyn_buf_append_uint64(db, cf_atomic64_get(&p_set->n_bytes_memory));
 	cf_dyn_buf_append_char(db, ':');
 
 	cf_dyn_buf_append_string(db, "truncate_lut=");
@@ -738,22 +738,22 @@ append_set_props(as_set *p_set, cf_dyn_buf *db)
 	// Configuration:
 
 	cf_dyn_buf_append_string(db, "stop-writes-count=");
-	cf_dyn_buf_append_uint64(db, cf_atomic64_get(p_set->stop_writes_count));
+	cf_dyn_buf_append_uint64(db, cf_atomic64_get(&p_set->stop_writes_count));
 	cf_dyn_buf_append_char(db, ':');
 
 	cf_dyn_buf_append_string(db, "set-enable-xdr=");
 
-	if (cf_atomic32_get(p_set->enable_xdr) == AS_SET_ENABLE_XDR_TRUE) {
+	if (cf_atomic32_get(&p_set->enable_xdr) == AS_SET_ENABLE_XDR_TRUE) {
 		cf_dyn_buf_append_string(db, "true");
 	}
-	else if (cf_atomic32_get(p_set->enable_xdr) == AS_SET_ENABLE_XDR_FALSE) {
+	else if (cf_atomic32_get(&p_set->enable_xdr) == AS_SET_ENABLE_XDR_FALSE) {
 		cf_dyn_buf_append_string(db, "false");
 	}
-	else if (cf_atomic32_get(p_set->enable_xdr) == AS_SET_ENABLE_XDR_DEFAULT) {
+	else if (cf_atomic32_get(&p_set->enable_xdr) == AS_SET_ENABLE_XDR_DEFAULT) {
 		cf_dyn_buf_append_string(db, "use-default");
 	}
 	else {
-		cf_dyn_buf_append_uint32(db, cf_atomic32_get(p_set->enable_xdr));
+		cf_dyn_buf_append_uint32(db, cf_atomic32_get(&p_set->enable_xdr));
 	}
 
 	cf_dyn_buf_append_char(db, ':');

--- a/as/src/base/scan.c
+++ b/as/src/base/scan.c
@@ -596,8 +596,8 @@ basic_scan_job_start(as_transaction* tr, as_namespace* ns, uint16_t set_id)
 	}
 
 	if (job->fail_on_cluster_change &&
-			(cf_atomic_int_get(ns->migrate_tx_partitions_remaining) != 0 ||
-			 cf_atomic_int_get(ns->migrate_rx_partitions_remaining) != 0)) {
+			(cf_atomic_int_get(&ns->migrate_tx_partitions_remaining) != 0 ||
+			 cf_atomic_int_get(&ns->migrate_rx_partitions_remaining) != 0)) {
 		// TODO - was AS_PROTO_RESULT_FAIL_UNAVAILABLE - ok?
 		cf_warning(AS_SCAN, "basic scan job not started - migration");
 		as_job_destroy(_job);
@@ -1298,7 +1298,7 @@ udf_bg_scan_job_finish(as_job* _job)
 {
 	udf_bg_scan_job* job = (udf_bg_scan_job*)_job;
 
-	while (cf_atomic32_get(job->n_active_tr) != 0) {
+	while (cf_atomic32_get(&job->n_active_tr) != 0) {
 		usleep(100);
 	}
 
@@ -1339,9 +1339,9 @@ udf_bg_scan_job_info(as_job* _job, as_mon_jobstat* stat)
 
 	sprintf(extra, ":udf-filename=%s:udf-function=%s:udf-active=%u:udf-success=%lu:udf-failed=%lu",
 			job->origin.def.filename, job->origin.def.function,
-			cf_atomic32_get(job->n_active_tr),
-			cf_atomic64_get(job->n_successful_tr),
-			cf_atomic64_get(job->n_failed_tr));
+			cf_atomic32_get(&job->n_active_tr),
+			cf_atomic64_get(&job->n_successful_tr),
+			cf_atomic64_get(&job->n_failed_tr));
 }
 
 //----------------------------------------------------------
@@ -1382,7 +1382,7 @@ udf_bg_scan_job_reduce_cb(as_index_ref* r_ref, void* udata)
 	as_record_done(r_ref, ns);
 
 	// TODO - replace this mechanism with signal-based counter?
-	while (cf_atomic32_get(job->n_active_tr) >
+	while (cf_atomic32_get(&job->n_active_tr) >
 			g_config.scan_max_udf_transactions) {
 		usleep(50);
 	}

--- a/as/src/base/secondary_index.c
+++ b/as/src/base/secondary_index.c
@@ -1099,8 +1099,8 @@ as_sindex_stats_str(as_namespace *ns, char * iname, cf_dyn_buf *db)
 
 	// A good thing to cache the stats first.
 	uint64_t ns_objects  = ns->n_objects;
-	uint64_t si_objects  = cf_atomic64_get(si->stats.n_objects);
-	uint64_t pending     = cf_atomic64_get(si->stats.recs_pending);
+	uint64_t si_objects  = cf_atomic64_get(&si->stats.n_objects);
+	uint64_t pending     = cf_atomic64_get(&si->stats.recs_pending);
 
 	uint64_t n_keys      = ai_btree_get_numkeys(si->imd);
 	uint64_t i_size      = ai_btree_get_isize(si->imd);
@@ -1121,24 +1121,24 @@ as_sindex_stats_str(as_namespace *ns, char * iname, cf_dyn_buf *db)
 		}
 	}
 
-	info_append_uint64(db, "loadtime", cf_atomic64_get(si->stats.loadtime));
+	info_append_uint64(db, "loadtime", cf_atomic64_get(&si->stats.loadtime));
 	// writes
-	info_append_uint64(db, "write_success", cf_atomic64_get(si->stats.n_writes) - cf_atomic64_get(si->stats.write_errs));
-	info_append_uint64(db, "write_error", cf_atomic64_get(si->stats.write_errs));
+	info_append_uint64(db, "write_success", cf_atomic64_get(&si->stats.n_writes) - cf_atomic64_get(&si->stats.write_errs));
+	info_append_uint64(db, "write_error", cf_atomic64_get(&si->stats.write_errs));
 	// delete
-	info_append_uint64(db, "delete_success", cf_atomic64_get(si->stats.n_deletes) - cf_atomic64_get(si->stats.delete_errs));
-	info_append_uint64(db, "delete_error", cf_atomic64_get(si->stats.delete_errs));
+	info_append_uint64(db, "delete_success", cf_atomic64_get(&si->stats.n_deletes) - cf_atomic64_get(&si->stats.delete_errs));
+	info_append_uint64(db, "delete_error", cf_atomic64_get(&si->stats.delete_errs));
 	// defrag
-	info_append_uint64(db, "stat_gc_recs", cf_atomic64_get(si->stats.n_defrag_records));
-	info_append_uint64(db, "stat_gc_time", cf_atomic64_get(si->stats.defrag_time));
+	info_append_uint64(db, "stat_gc_recs", cf_atomic64_get(&si->stats.n_defrag_records));
+	info_append_uint64(db, "stat_gc_time", cf_atomic64_get(&si->stats.defrag_time));
 
 	// Cache values
-	uint64_t agg        = cf_atomic64_get(si->stats.n_aggregation);
-	uint64_t agg_rec    = cf_atomic64_get(si->stats.agg_num_records);
-	uint64_t agg_size   = cf_atomic64_get(si->stats.agg_response_size);
-	uint64_t lkup       = cf_atomic64_get(si->stats.n_lookup);
-	uint64_t lkup_rec   = cf_atomic64_get(si->stats.lookup_num_records);
-	uint64_t lkup_size  = cf_atomic64_get(si->stats.lookup_response_size);
+	uint64_t agg        = cf_atomic64_get(&si->stats.n_aggregation);
+	uint64_t agg_rec    = cf_atomic64_get(&si->stats.agg_num_records);
+	uint64_t agg_size   = cf_atomic64_get(&si->stats.agg_response_size);
+	uint64_t lkup       = cf_atomic64_get(&si->stats.n_lookup);
+	uint64_t lkup_rec   = cf_atomic64_get(&si->stats.lookup_num_records);
+	uint64_t lkup_size  = cf_atomic64_get(&si->stats.lookup_response_size);
 	uint64_t query      = agg      + lkup;
 	uint64_t query_rec  = agg_rec  + lkup_rec;
 	uint64_t query_size = agg_size + lkup_size;
@@ -1739,7 +1739,7 @@ as_sindex_destroy(as_namespace *ns, as_sindex_metadata *imd)
 void
 as_sindex_clear_stats_on_empty_index(as_sindex *si)
 {
-	cf_atomic64_add(&si->stats.n_deletes, cf_atomic64_get(si->stats.n_objects));
+	cf_atomic64_add(&si->stats.n_deletes, cf_atomic64_get(&si->stats.n_objects));
 	cf_atomic64_set(&si->stats.n_keys, 0);
 	cf_atomic64_set(&si->stats.n_objects, 0);
 }
@@ -4413,11 +4413,11 @@ as_sindex_ticker(as_namespace * ns, as_sindex * si, uint64_t n_obj_scanned, uint
 			si_name = si->imd->iname;
 		}
 		else {
-			si_memory = (uint64_t)cf_atomic64_get(ns->n_bytes_sindex_memory);
+			si_memory = (uint64_t)cf_atomic64_get(&ns->n_bytes_sindex_memory);
 			si_name = "<all>";
 		}
 
-		uint64_t n_objects       = cf_atomic64_get(ns->n_objects);
+		uint64_t n_objects       = cf_atomic64_get(&ns->n_objects);
 		uint64_t pct_obj_scanned = n_objects == 0 ? 100 : ((n_obj_scanned * 100) / n_objects);
 		uint64_t elapsed         = (cf_getms() - start_time);
 		uint64_t est_time        = (elapsed * n_objects)/n_obj_scanned - elapsed;
@@ -4441,7 +4441,7 @@ as_sindex_ticker_done(as_namespace * ns, as_sindex * si, uint64_t start_time)
 		si_name = si->imd->iname;
 	}
 	else {
-		si_memory = (uint64_t)cf_atomic64_get(ns->n_bytes_sindex_memory);
+		si_memory = (uint64_t)cf_atomic64_get(&ns->n_bytes_sindex_memory);
 		si_name = "<all>";
 	}
 

--- a/as/src/base/thr_demarshal.c
+++ b/as/src/base/thr_demarshal.c
@@ -311,7 +311,7 @@ thr_demarshal_set_buffer(cf_socket *sock, buffer_type type, int size)
 		return -1; // cf_crash() should have a "noreturn" attribute, but is a macro
 	}
 
-	int tmp = ck_pr_load_int(max);
+	int tmp = cf_atomic_int_get(max);
 
 	if (tmp < 0) {
 		if (thr_demarshal_read_integer(proc, &tmp) < 0) {

--- a/as/src/base/thr_demarshal.c
+++ b/as/src/base/thr_demarshal.c
@@ -315,8 +315,11 @@ thr_demarshal_set_buffer(cf_socket *sock, buffer_type type, int size)
 
 	if (tmp < 0) {
 		if (thr_demarshal_read_integer(proc, &tmp) < 0) {
-			cf_warning(AS_DEMARSHAL, "Failed to read %s; should be at least %d. Please verify.", proc, size);
-			tmp = size;
+			cf_warning(AS_DEMARSHAL, "Failed to read %s.", proc);
+			tmp = size; // assuming its going to work
+		}
+		else {
+			cf_atomic_int_set(max, tmp);
 		}
 	}
 
@@ -325,8 +328,6 @@ thr_demarshal_set_buffer(cf_socket *sock, buffer_type type, int size)
 				tmp, size, proc);
 		return -1;
 	}
-
-	ck_pr_cas_int(max, -1, tmp);
 
 	switch (type) {
 	case BUFFER_TYPE_RECEIVE:

--- a/as/src/base/thr_nsup.c
+++ b/as/src/base/thr_nsup.c
@@ -237,7 +237,7 @@ get_cold_start_ttl_range(as_namespace* ns, uint32_t now)
 	uint64_t max_void_time = 0;
 
 	for (int n = 0; n < AS_PARTITIONS; n++) {
-		uint64_t partition_max_void_time = cf_atomic32_get(ns->partitions[n].max_void_time);
+		uint64_t partition_max_void_time = cf_atomic32_get(&ns->partitions[n].max_void_time);
 
 		if (partition_max_void_time > max_void_time) {
 			max_void_time = partition_max_void_time;
@@ -773,7 +773,7 @@ get_ttl_range(as_namespace* ns, uint32_t now)
 
 		as_partition_release(&rsv);
 
-		uint64_t partition_max_void_time = cf_atomic32_get(ns->partitions[n].max_void_time);
+		uint64_t partition_max_void_time = cf_atomic32_get(&ns->partitions[n].max_void_time);
 
 		if (partition_max_void_time > max_master_void_time) {
 			max_master_void_time = partition_max_void_time;

--- a/as/src/base/thr_query.c
+++ b/as/src/base/thr_query.c
@@ -856,12 +856,12 @@ int
 qtr_release(as_query_transaction *qtr, char *fname, int lineno)
 {
 	if (qtr) {
-		int val = cf_rc_release(qtr);
+		unsigned val = cf_rc_release(qtr);
 		if (val == 0) {
-			cf_detail(AS_QUERY, "Released qtr [%s:%d] %p %d ", fname, lineno, qtr, val);
+			cf_detail(AS_QUERY, "Released qtr [%s:%d] %p %u ", fname, lineno, qtr, val);
 			query_transaction_done(qtr);
 		}
-		cf_detail(AS_QUERY, "Released qtr [%s:%d] %p %d ", fname, lineno, qtr, val);
+		cf_detail(AS_QUERY, "Released qtr [%s:%d] %p %u ", fname, lineno, qtr, val);
 	}
 	return AS_QUERY_OK;
 }
@@ -872,8 +872,8 @@ qtr_reserve(as_query_transaction *qtr, char *fname, int lineno)
 	if (!qtr) {
 		return AS_QUERY_ERR;
 	}
-	int val = cf_rc_reserve(qtr);
-	cf_detail(AS_QUERY, "Reserved qtr [%s:%d] %p %d ", fname, lineno, qtr, val);
+	unsigned val = cf_rc_reserve(qtr);
+	cf_detail(AS_QUERY, "Reserved qtr [%s:%d] %p %u ", fname, lineno, qtr, val);
 	return AS_QUERY_OK;
 }
 // **************************************************************************************************

--- a/as/src/base/transaction.c
+++ b/as/src/base/transaction.c
@@ -406,13 +406,13 @@ as_multi_rec_transaction_error(as_transaction* tr, uint32_t error_code)
 void
 as_release_file_handle(as_file_handle *proto_fd_h)
 {
-	int rc = cf_rc_release(proto_fd_h);
+	unsigned rc = cf_rc_release(proto_fd_h);
 
 	if (rc > 0) {
 		return;
 	}
 	else if (rc < 0) {
-		cf_warning(AS_PROTO, "release file handle: negative ref-count %d", rc);
+		cf_warning(AS_PROTO, "release file handle: negative ref-count %u", rc);
 		return;
 	}
 

--- a/as/src/base/udf_aerospike.c
+++ b/as/src/base/udf_aerospike.c
@@ -508,7 +508,7 @@ udf_aerospike__apply_update_atomic(udf_record *urecord)
 			goto Rollback;
 		}
 
-		if (cf_atomic32_get(rd->ns->stop_writes) == 1) {
+		if (cf_atomic32_get(&rd->ns->stop_writes) == 1) {
 			cf_warning(AS_UDF, "UDF failed by stop-writes, record will not be updated");
 			failmax = (int)urecord->nupdates;
 			goto Rollback;

--- a/as/src/fabric/fabric.c
+++ b/as/src/fabric/fabric.c
@@ -370,7 +370,7 @@ as_fabric_msg_queue_dump()
 	int total_alloced_msgs = 0;
 
 	for (int i = 0; i < M_TYPE_MAX; i++) {
-		int num_of_type = cf_atomic_int_get(g_num_msgs_by_type[i]);
+		int num_of_type = cf_atomic_int_get(&g_num_msgs_by_type[i]);
 
 		total_alloced_msgs += num_of_type;
 
@@ -379,7 +379,7 @@ as_fabric_msg_queue_dump()
 		}
 	}
 
-	int num_msgs = cf_atomic_int_get(g_num_msgs);
+	int num_msgs = cf_atomic_int_get(&g_num_msgs);
 
 	if (abs(num_msgs - total_alloced_msgs) > 2) {
 		cf_warning(AS_FABRIC, "num msgs (%d) != total alloc'd msgs (%d)", num_msgs, total_alloced_msgs);

--- a/as/src/fabric/hlc.c
+++ b/as/src/fabric/hlc.c
@@ -563,5 +563,5 @@ hlc_ts_set(as_hlc_timestamp old_value, as_hlc_timestamp new_value,
 	if (jump > HLC_JUMP_WARN && old_value > 0) {
 		INFO("HLC jumped by %"PRIu64" ms cause:%"PRIx64" old:%"PRIu64" new:%"PRIu64, jump, source, old_value, new_value);
 	}
-	return ck_pr_cas_64(&g_now, old_value, new_value);
+       return cf_atomic64_cas(&g_now, &old_value, new_value);
 }

--- a/as/src/fabric/hlc.c
+++ b/as/src/fabric/hlc.c
@@ -541,7 +541,7 @@ hlc_logical_ts_set(as_hlc_timestamp* hlc_ts, uint16_t logical_ts)
 static as_hlc_timestamp
 hlc_ts_get()
 {
-	return ck_pr_load_64(&g_now);
+	return cf_atomic64_get(&g_now);
 }
 
 /**

--- a/as/src/fabric/migrate.c
+++ b/as/src/fabric/migrate.c
@@ -879,7 +879,7 @@ run_emigration_reinserter(void *arg)
 	emigration_state emig_state;
 
 	// Reduce over the reinsert hash until finished.
-	while ((emig_state = cf_atomic32_get(emig->state)) != EMIG_STATE_ABORTED) {
+	while ((emig_state = cf_atomic32_get(&emig->state)) != EMIG_STATE_ABORTED) {
 		if (emig->cluster_key != as_exchange_cluster_key()) {
 			cf_atomic32_set(&emig->state, EMIG_STATE_ABORTED);
 			return NULL;
@@ -1010,7 +1010,7 @@ emigrate_tree_reduce_fn(as_index_ref *r_ref, void *udata)
 
 	uint32_t waits = 0;
 
-	while (cf_atomic32_get(emig->bytes_emigrating) > MAX_BYTES_EMIGRATING &&
+	while (cf_atomic32_get(&emig->bytes_emigrating) > MAX_BYTES_EMIGRATING &&
 			emig->cluster_key == as_exchange_cluster_key()) {
 		usleep(1000);
 

--- a/as/src/fabric/skew_monitor.c
+++ b/as/src/fabric/skew_monitor.c
@@ -623,7 +623,7 @@ skew_monitor_hb_plugin_set_fn(msg* msg)
 	pthread_mutex_unlock(&g_self_skew_lock);
 
 	cf_clock now = cf_getms();
-	if (cf_atomic64_get(g_last_skew_check_time) + skew_check_interval() < now) {
+	if (cf_atomic64_get(&g_last_skew_check_time) + skew_check_interval() < now) {
 		skew_monitor_update();
 	}
 }
@@ -768,7 +768,7 @@ as_skew_monitor_init()
 uint64_t
 as_skew_monitor_skew()
 {
-	return cf_atomic64_get(g_skew);
+	return cf_atomic64_get(&g_skew);
 }
 
 /**

--- a/as/src/transaction/write.c
+++ b/as/src/transaction/write.c
@@ -812,7 +812,7 @@ write_master_preprocessing(as_transaction* tr)
 	}
 
 	// ns->stop_writes is set by thr_nsup if configured threshold is breached.
-	if (cf_atomic32_get(ns->stop_writes) == 1) {
+	if (cf_atomic32_get(&ns->stop_writes) == 1) {
 		write_master_failed(tr, 0, false, 0, 0, AS_PROTO_RESULT_FAIL_OUT_OF_SPACE);
 		return false;
 	}

--- a/cf/include/enhanced_alloc.h
+++ b/cf/include/enhanced_alloc.h
@@ -125,6 +125,6 @@ void *cf_rc_alloc(size_t sz);
 void cf_rc_free(void *p);
 
 int32_t cf_rc_count(const void *p);
-int32_t cf_rc_reserve(void *p);
-int32_t cf_rc_release(void *p);
-int32_t cf_rc_releaseandfree(void *p);
+uint32_t cf_rc_reserve(void *p);
+uint32_t cf_rc_release(void *p);
+uint32_t cf_rc_releaseandfree(void *p);

--- a/cf/src/alloc.c
+++ b/cf/src/alloc.c
@@ -178,7 +178,8 @@ hook_get_site_id(const void *ra)
 		// this slot in the meantime, keep looping. Otherwise return the
 		// slot index.
 
-		if (site_ra == NULL && ck_pr_cas_ptr(g_site_ras + site_id, NULL, (void *)ra)) {
+		void *old_value = NULL;
+		if (cf_atomic_p_cas(g_site_ras + site_id, &old_value, ra)) {
 			cf_atomic32_incr(&g_n_site_ras);
 			return site_id;
 		}

--- a/cf/src/alloc.c
+++ b/cf/src/alloc.c
@@ -1051,28 +1051,28 @@ cf_rc_free(void *p)
 	jem_sdallocx(head, jem_sz, 0);
 }
 
-int32_t
+uint32_t
 cf_rc_reserve(void *p)
 {
 	cf_rc_header *head = (cf_rc_header *)p - 1;
 	return cf_atomic32_incr(&head->rc);
 }
 
-int32_t
+uint32_t
 cf_rc_release(void *p)
 {
 	cf_rc_header *head = (cf_rc_header *)p - 1;
-	int32_t rc = cf_atomic32_decr(&head->rc);
-	cf_assert(rc >= 0, CF_ALLOC, "reference count underflow: %d (0x%x)", rc, rc);
+	uint32_t rc = cf_atomic32_decr(&head->rc);
+	cf_assert(rc < UINT32_MAX, CF_ALLOC, "reference count underflow: %d (0x%x)", rc, rc);
 	return rc;
 }
 
-int32_t
+uint32_t
 cf_rc_releaseandfree(void *p)
 {
 	cf_rc_header *head = (cf_rc_header *)p - 1;
-	int32_t rc = cf_atomic32_decr(&head->rc);
-	cf_assert(rc >= 0, CF_ALLOC, "reference count underflow: %d (0x%x)", rc, rc);
+	uint32_t rc = cf_atomic32_decr(&head->rc);
+	cf_assert(rc < UINT32_MAX, CF_ALLOC, "reference count underflow: %d (0x%x)", rc, rc);
 
 	if (rc > 0) {
 		return rc;

--- a/cf/src/msg.c
+++ b/cf/src/msg.c
@@ -210,7 +210,7 @@ msg_create(msg_type type)
 void
 msg_destroy(msg *m)
 {
-	int cnt = cf_rc_release(m);
+	unsigned cnt = cf_rc_release(m);
 
 	if (cnt == 0) {
 		for (uint32_t i = 0; i < m->n_fields; i++) {

--- a/cf/src/shash.c
+++ b/cf/src/shash.c
@@ -175,7 +175,7 @@ cf_shash_get_size(cf_shash *h)
 	cf_assert(h, CF_MISC, "bad param");
 
 	// For now, not bothering with different methods per lock mode.
-	return cf_atomic32_get(h->n_elements);
+	return cf_atomic32_get(&h->n_elements);
 }
 
 void

--- a/make_in/Makefile.in
+++ b/make_in/Makefile.in
@@ -81,6 +81,11 @@ COMMON_CFLAGS += -MMD
 # Require strict warning-free compilation.
 COMMON_CFLAGS += -Werror
 
+ifdef GCC_ATOMICS
+COMMON_CFLAGS += -DGCC_ATOMICS=1
+endif
+
+
 CFLAGS = $(COMMON_CFLAGS) -DMARCH_$(MARCH_NATIVE)
 
 # Define a macro for the base source file name.


### PR DESCRIPTION
This is largely a change of api for the cf_atomic*_get functions introduced in https://github.com/aerospike/aerospike-common/pull/12 and is required to be merged at the same time.

In a few cases the concurrency kit implementation was replaces with the cf wrapper.

A GCC_ATOMICS makefile option was added to generate corresponding GCC_ATOMICS in the common code.

cf_rc_release* where changed to avoid compile warnings about implicit type conversion.