### PR TITLE
Replace pwrite with asynchronous write

### DIFF
--- a/as/include/fabric/exchange.h
+++ b/as/include/fabric/exchange.h
@@ -44,8 +44,9 @@
  * 2 - 4.5.2 - for AER-6035 (AP uniform-balance + quiesce bug).
  * 3 - 4.5.3 - for new pickle format.
  * 4 - 4.7.0 - for AER-6128 (AP uniform-balance empty master selection bug).
+ * 5 - 4.7.0.3 - for AER-6143 (SC quiesce with non-roster nodes bug).
  */
-#define AS_EXCHANGE_COMPATIBILITY_ID 4
+#define AS_EXCHANGE_COMPATIBILITY_ID 5
 
 /**
  * Number of quantum intervals in orphan state after which client transactions

--- a/as/src/Makefile
+++ b/as/src/Makefile
@@ -163,7 +163,8 @@ else
 endif
 
 LIBRARIES += -L$(S2) -ls2 -ls2cellid -lgoogle-strings -lgoogle-base \
-			-lgoogle-util-coding -lgoogle-util-math -lstdc++
+			-lgoogle-util-coding -lgoogle-util-math -lstdc++ \
+			-laio
 
 LIBRARIES := $(AS_LIBRARIES) $(LIBRARIES)
 

--- a/as/src/base/particle_map.c
+++ b/as/src/base/particle_map.c
@@ -1253,6 +1253,12 @@ cdt_context_unwind_map(cdt_context *ctx, cdt_ctx_list_stack_entry *p)
 		return;
 	}
 
+	if (! order_index_is_filled(&orig.ordidx)) { // no prior order index
+		order_index_set_sorted(&map.ordidx, &map.offidx, map.contents,
+				map.content_sz, SORT_BY_VALUE);
+		return;
+	}
+
 	uint32_t off = offset_index_get_const(&map.offidx, p->idx);
 
 	msgpack_in mp = {

--- a/as/src/base/particle_map.c
+++ b/as/src/base/particle_map.c
@@ -4516,6 +4516,12 @@ packed_map_get_remove_all(const packed_map *map, cdt_op_mem *com)
 		// no break
 	case RESULT_TYPE_INDEX:
 	case RESULT_TYPE_RANK: {
+		if (! result->is_multi) {
+			cf_assert(map->ele_count == 1, AS_PARTICLE, "single result op with multiple results %u", map->ele_count);
+			as_bin_set_int(result->result, 0);
+			break;
+		}
+
 		define_int_list_builder(builder, result->alloc, map->ele_count);
 
 		cdt_container_builder_add_int_range(&builder, 0, map->ele_count,


### PR DESCRIPTION
ASD uses synchronous reads/writes for IOs on disk/file devices.
During startup ASD creates a thread per storage backend. The thread
consumes a single ssd_write_buf from queue and issues a synchronous
write to disk. As a result, only a single write IO can be
outstanding at a time.

The size of the Q from which writer thread consumes writes is limited.
If the writer thread is not able to flush at the rate of client, ASD
start issuing OVERLOAD errors.

This is a first attempt to issue asynchronous writes to device, **raising
the pull request just to get feedback. The work is not complete,
however I would like to get early review.**

I have written a benchmark tool, which write 4096 sized objects with
various IO depths (from 1 to 128). It always fails with OVERLOAD error.
Besides, while the benchmark is running, IOSTAT reports only single
outstanding IO to disk.

The overload error is gone with the modified code and the IO
Request Q depth reported by IOSTAT is continuously more than 1.

The code change includes
1. During startup for each SSD device
    - create a additional cf_poll, register a eventfd for AsyncIO
    - create a separate eventfd for flush_write_q an shadow_write_q.
      Both the eventfds are registered with same poll.
2. Removed the thread which serves shadow write q. Create a single
    thread per SSD for all writes
3. signal eventfd, when a ssd_write_buf is pushed into any q.
4. The writer thread
     - reads as many ssd_write_buf as possible, fills IOCB, and
       issues multiple writes in a single system call.
     - The writer thread also handle the write completions

Signed-off-by: Prasad Joshi <prasadjoshi.linux@gmail.com>