### PR TITLE
thr_info: avoid printing null params

### DIFF
--- a/as/src/base/aggr.c
+++ b/as/src/base/aggr.c
@@ -1,7 +1,7 @@
 /*
  * aggr.c
  *
- * Copyright (C) 2014-2015 Aerospike, Inc.
+ * Copyright (C) 2014-2019 Aerospike, Inc.
  *
  * Portions may be licensed to Aerospike, Inc. under one or more contributor
  * license agreements.

--- a/as/src/base/thr_info.c
+++ b/as/src/base/thr_info.c
@@ -2222,7 +2222,7 @@ info_command_config_get_with_params(char *name, char *params, cf_dyn_buf *db)
 int
 info_command_config_get(char *name, char *params, cf_dyn_buf *db)
 {
-	cf_debug(AS_INFO, "config-get command received: params %s", params);
+	cf_debug(AS_INFO, "config-get command received: params %s", (params == NULL) ? "(null)" : params);
 
 	if (params && *params != 0) {
 		info_command_config_get_with_params(name, params, db);

--- a/as/src/fabric/migrate.c
+++ b/as/src/fabric/migrate.c
@@ -1277,7 +1277,7 @@ immigration_handle_start_request(cf_node src, msg *m)
 
 			if (immig0->cluster_key != cluster_key) {
 				immigration_release(immig0);
-				return; // other node reused an immig_id, allow reaper to reap
+				return; // other node reused an emig_id, allow reaper to reap
 			}
 
 			immig = immig0; // ...  and use original

--- a/as/src/fabric/migrate.c
+++ b/as/src/fabric/migrate.c
@@ -1296,7 +1296,8 @@ immigration_handle_start_request(cf_node src, msg *m)
 		return;
 	case AS_MIGRATE_AGAIN:
 		// Remove from hash so that the immig can be tried again.
-		cf_rchash_delete(g_immigration_hash, (void *)&hkey, sizeof(hkey));
+		cf_rchash_delete_object(g_immigration_hash, (void *)&hkey, sizeof(hkey),
+				(void *)immig);
 		immigration_release(immig);
 		immigration_ack_start_request(src, m, OPERATION_START_ACK_EAGAIN);
 		return;

--- a/as/src/fabric/migrate.c
+++ b/as/src/fabric/migrate.c
@@ -1073,7 +1073,7 @@ immigration_reaper_reduce_fn(const void *key, uint32_t keylen, void *object,
 	immigration *immig = (immigration *)object;
 
 	if (immig->start_recv_ms == 0) {
-		// If the start time isn't set, immigration is still being processed.
+		// Still in immigration start.
 		return CF_RCHASH_OK;
 	}
 
@@ -1296,6 +1296,7 @@ immigration_handle_start_request(cf_node src, msg *m)
 		return;
 	case AS_MIGRATE_AGAIN:
 		// Remove from hash so that the immig can be tried again.
+		// Note - no real need to specify object, but paranoia costs nothing.
 		cf_rchash_delete_object(g_immigration_hash, (void *)&hkey, sizeof(hkey),
 				(void *)immig);
 		immigration_release(immig);

--- a/as/src/storage/drv_ssd.c
+++ b/as/src/storage/drv_ssd.c
@@ -2927,6 +2927,7 @@ ssd_init_synchronous(drv_ssds *ssds)
 	if (prefix_first->last_evict_void_time != 0) {
 		if (ns->smd_evict_void_time == 0) {
 			ns->smd_evict_void_time = prefix_first->last_evict_void_time;
+			ns->evict_void_time = ns->smd_evict_void_time;
 			// Leave header threshold in case we don't commit SMD threshold.
 		}
 		else {

--- a/as/src/transaction/write.c
+++ b/as/src/transaction/write.c
@@ -1329,7 +1329,8 @@ write_master_dim(as_transaction* tr, as_storage_rd* rd,
 	rd->bins = new_bins;
 
 	// Collect bins (old or intermediate versions) to destroy on cleanup.
-	as_bin cleanup_bins[m->n_ops];
+	// Note - one delete-all op may destroy many bins. Size is max possible + 1.
+	as_bin cleanup_bins[n_old_bins + m->n_ops];
 	uint32_t n_cleanup_bins = 0;
 
 	//------------------------------------------------------


### PR DESCRIPTION
When building aerospike-server with gcc-9 (Ubuntu 19.10), the compilation fails with:

```
In file included from /home/ubuntu/dev/aerospike-server/cf/include/socket.h:35,
                 from ../include/base/proto.h:39,
                 from ../include/base/thr_info.h:31,
                 from base/thr_info.c:23:
In function ‘info_command_config_get’,
    inlined from ‘info_get_config’ at base/thr_info.c:4971:9:
/home/ubuntu/dev/aerospike-server/cf/include/fault.h:445:5: error: ‘%s’ directive argument is null [-Werror=format-overflow=]
  445 |     cf_fault_event((context), severity, __FILENAME__, __LINE__, (__msg), ##__VA_ARGS__))
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/ubuntu/dev/aerospike-server/cf/include/fault.h:452:23: note: in expansion of macro ‘__SEVLOG’
  452 | #define cf_debug(...) __SEVLOG(CF_DEBUG, ##__VA_ARGS__)
      |                       ^~~~~~~~
base/thr_info.c:2099:2: note: in expansion of macro ‘cf_debug’
 2099 |  cf_debug(AS_INFO, "config-get command received: params %s", params);
      |  ^~~~~~~~
cc1: all warnings being treated as errors
```

I'm not sure if this extra null-check is the best way of fixing it. Suggestions are very much appreciated.