### PR TITLE
avoid uint32_t overflow when calculating ns->storage_max_write_q

### DIFF
--- a/as/src/storage/drv_ssd.c
+++ b/as/src/storage/drv_ssd.c
@@ -3328,8 +3328,8 @@ as_storage_init_ssd(as_namespace *ns)
 
 	// The queue limit is more efficient to work with.
 	ns->storage_max_write_q = (uint32_t)
-			(ssds->n_ssds * ns->storage_max_write_cache) /
-			ns->storage_write_block_size;
+			(ssds->n_ssds * ns->storage_max_write_cache /
+			ns->storage_write_block_size);
 
 	// Minimize how often we recalculate this.
 	ns->defrag_lwm_size =


### PR DESCRIPTION
Misplaced parenthesis causes incorrect cast from uint64_t to uint32_t.
E.g. when 'max-write-cache' is 4G, ns->storage_max_write_q is calculated
to be zero.