### PR TITLE
correctly disable stack clash protection

### DIFF
--- a/as/src/base/thr_info.c
+++ b/as/src/base/thr_info.c
@@ -880,15 +880,10 @@ info_command_cluster_stable(char *name, char *params, cf_dyn_buf *db)
 			return 0;
 		}
 
-		if (rv == -1) {
-			// Ensure migrations are complete for all namespaces.
+		uint32_t n_namespaces = g_config.n_namespaces;
+		as_namespace** namespaces = g_config.namespaces;
 
-			if (as_partition_balance_remaining_migrations() != 0) {
-				cf_dyn_buf_append_string(db, "ERROR::unstable-cluster");
-				return 0;
-			}
-		}
-		else {
+		if (rv == 0) {
 			// Ensure migrations are complete for the requested namespace only.
 			as_namespace *ns = as_namespace_get_byname(ns_name);
 
@@ -897,6 +892,13 @@ info_command_cluster_stable(char *name, char *params, cf_dyn_buf *db)
 				cf_dyn_buf_append_string(db, "ERROR::unknown-namespace");
 				return 0;
 			}
+
+			n_namespaces = 1;
+			namespaces = &namespaces[ns->ix];
+		}
+
+		for (uint32_t ns_ix = 0; ns_ix < n_namespaces; ns_ix++) {
+			as_namespace* ns = namespaces[ns_ix];
 
 			if (ns->migrate_tx_partitions_remaining +
 					ns->migrate_rx_partitions_remaining +

--- a/as/src/base/udf_record.c
+++ b/as/src/base/udf_record.c
@@ -677,7 +677,7 @@ udf_record_bin_names(const as_rec* rec, as_rec_bin_names_callback cb,
 		if (as_bin_is_live(b)) {
 			const char* name = as_bin_get_name_from_id(ns, b->id);
 
-			strcpy(bin_names + (i * AS_BIN_NAME_MAX_SZ), name);
+			strcpy(bin_names + (n_live_bins * AS_BIN_NAME_MAX_SZ), name);
 			n_live_bins++;
 		}
 	}

--- a/cf/src/arenax_ce.c
+++ b/cf/src/arenax_ce.c
@@ -1,7 +1,7 @@
 /*
  * arenax_ce.c
  *
- * Copyright (C) 2014-2020 Aerospike, Inc.
+ * Copyright (C) 2014-2022 Aerospike, Inc.
  *
  * Portions may be licensed to Aerospike, Inc. under one or more contributor
  * license agreements.

--- a/cf/src/hardware.c
+++ b/cf/src/hardware.c
@@ -2701,13 +2701,39 @@ cf_storage_is_root_fs(const char *path)
 	return vfs.f_fsid == root_id;
 }
 
+static bool
+write_file_int_if(const char *path, uint32_t val)
+{
+	int64_t cur_val;
+
+	if (cf_os_read_int_from_file(path, &cur_val) != CF_OS_FILE_RES_OK) {
+		cf_crash(CF_HARDWARE, "can't open %s for reading", path);
+	}
+
+	if ((int64_t)val == cur_val) {
+		return true; // already set
+	}
+
+	char val_str[16];
+	size_t limit = (size_t)sprintf(val_str, "%u", val);
+
+	return write_file(path, (const void*)val_str, limit) == CF_OS_FILE_RES_OK;
+}
+
 void
 cf_page_cache_dirty_limits(void)
 {
-	write_file_safe("/proc/sys/vm/dirty_bytes", "16777216", 8);
-	write_file_safe("/proc/sys/vm/dirty_background_bytes", "1", 1);
-	write_file_safe("/proc/sys/vm/dirty_expire_centisecs", "1", 1);
-	write_file_safe("/proc/sys/vm/dirty_writeback_centisecs", "10", 2);
+	if (! (write_file_int_if("/proc/sys/vm/dirty_bytes", 16777216) &&
+			write_file_int_if("/proc/sys/vm/dirty_background_bytes", 1) &&
+			write_file_int_if("/proc/sys/vm/dirty_expire_centisecs", 1) &&
+			write_file_int_if("/proc/sys/vm/dirty_writeback_centisecs", 10))) {
+		cf_crash_nostack(CF_HARDWARE, "each of: "
+				"/proc/sys/vm/dirty_bytes = 16777216, "
+				"/proc/sys/vm/dirty_background_bytes = 1, "
+				"/proc/sys/vm/dirty_expire_centisecs = 1, "
+				"/proc/sys/vm/dirty_writeback_centisecs = 10 "
+				"must be set before starting server - can't write to file(s)");
+	}
 }
 
 bool

--- a/make_in/Makefile.in
+++ b/make_in/Makefile.in
@@ -31,7 +31,7 @@ SRCDIR =
 MARCH_NATIVE = $(shell uname -m)
 
 # If GCC v4.4.7 or later, use DWARF version 4, othewise use version 2:
-ifeq ($(shell $(DEPTH)/build/VersionCheck.py 'gcc -dumpversion' 4.4.7), 1)
+ifeq ($(shell $(DEPTH)/build/VersionCheck.py '$(CC) -dumpversion' 4.4.7), 1)
   DWARF_VERSION=4
 else
   DWARF_VERSION=2
@@ -79,10 +79,12 @@ COMMON_CFLAGS += -MMD
 COMMON_CFLAGS += -Werror
 
 # In Ubuntu 20.04 and RHEL8, GCC has stack clash protection enabled by default.
-COMMON_FLAGS += -fno-stack-clash-protection
+ifeq ($(shell $(DEPTH)/build/VersionCheck.py '$(CC) -dumpversion' 8), 1)
+  COMMON_CFLAGS += -fno-stack-clash-protection
+endif
 
 # Override certain warnings under GCC v9+.
-ifeq ($(shell $(DEPTH)/build/VersionCheck.py 'gcc -dumpversion' 9), 1)
+ifeq ($(shell $(DEPTH)/build/VersionCheck.py '$(CC) -dumpversion' 9), 1)
   # Disable compilation failure due to warnings about possibly unaligned pointers into packed structs.
   COMMON_CFLAGS += -Wno-address-of-packed-member
 endif


### PR DESCRIPTION
Stack clash protection is intended to be disabled by -fno-stack-clash-protection. But the compiler option is added to unused variable "COMMON_FLAGS" instead of "COMMON_CFLAGS" in Makefile.

This change correctly disables stack clash protection if the compiler supports. This also fixes the compiler version check when compilers other than "gcc" are used (e.g. make CC=gcc-9).