### PR TITLE
Fix memory leak in `valgrind_check` cleanup loop

### DIFF
--- a/cf/src/alloc.c
+++ b/cf/src/alloc.c
@@ -610,9 +610,9 @@ valgrind_check(void)
 		cf_crash_nostack(CF_ALLOC, "Valgrind redirected malloc() to glibc; please run Valgrind with --soname-synonyms=somalloc=nouserintercepts");
 	}
 
-	for (uint32_t i = 0; i < tries; ++i) {
-		free(p1[tries]);
-		cf_free(p2[tries]);
+	for (uint32_t i = 0; i <= tries; ++i) {
+		free(p1[i]);
+		cf_free(p2[i]);
 	}
 }
 


### PR DESCRIPTION
The cleanup loop had two bugs:
1. Used `tries` as the array index instead of `i`, freeing the wrong allocation repeatedly
2. Used `< tries` instead of `<= tries`, skipping the successful allocation entirely when succeeding on the first try
