### PR TITLE
Hint index arena memory to use transparent hugepages (CE)

### DIFF
--- a/cf/src/arenax_ce.c
+++ b/cf/src/arenax_ce.c
@@ -28,6 +28,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <sys/mman.h>
 
 #include "citrusleaf/alloc.h"
 
@@ -69,6 +70,8 @@ cf_arenax_add_stage(cf_arenax* arena)
 				arena->stage_size, arena->stage_count);
 		return CF_ARENAX_ERR_STAGE_CREATE;
 	}
+
+	(void)madvise(p_stage, arena->stage_size, MADV_HUGEPAGE);
 
 	arena->stages[arena->stage_count++] = p_stage;
 


### PR DESCRIPTION
Primary index in CE is large and accessed randomly, making it prone to TLB misses. Backing it with 2 MiB huge pages instead of 4 KiB reduces both the miss rate and the cost of each miss (fewer page-table levels to walk), which matters most on multi-NUMA hosts where a miss can require a cross-node walk.

With THP=madvise, the kernel only promotes memory that is explicitly hinted via madvise(MADV_HUGEPAGE). jemalloc does not do this for arena allocations, so the index stays on 4 KiB pages even when an operator sets THP=madvise. This patch adds that hint after each arena stage is allocated.

The hint is advisory only and entirely opt-in. It has no effect unless an operator has already set THP=madvise, and there is no behavior change under THP=never. Existing best-practices checks pass under both THP=never and THP=madvise.

High-throughput random-read workloads saw reduced CPU usage and reduced tail latency with the following configuration:
    echo never   | sudo tee /sys/kernel/mm/transparent_hugepage/defrag
    echo 0       | sudo tee /sys/kernel/mm/transparent_hugepage/khugepaged/max_ptes_none
    echo 200     | sudo tee /sys/kernel/mm/transparent_hugepage/khugepaged/scan_sleep_millisecs
    echo 8192    | sudo tee /sys/kernel/mm/transparent_hugepage/khugepaged/pages_to_scan
    echo madvise | sudo tee /sys/kernel/mm/transparent_hugepage/enabled

defrag=never avoids synchronous compaction stalls on first touch of newly madvised arena memory, which is on the write path; khugepaged still collapses the memory into hugepages in the background regardless of the defrag setting. The khugepaged tuning makes it scan more frequently and more aggressively, and max_ptes_none=0 avoids collapsing a stage before it is fully populated, keeping RSS proportional to actual index usage.